### PR TITLE
USB: Mark utr_t.bIsTransferDone volatile

### DIFF
--- a/inc/usb.h
+++ b/inc/usb.h
@@ -1695,7 +1695,7 @@ typedef struct utr_t
     DEV_REQ_T   setup;                /*!< buffer for setup packet               \hideinitializer */
     EP_INFO_T   *ep;                  /*!< associated endpoint                   \hideinitializer */
     uint8_t     *buff;                /*!< transfer buffer                       \hideinitializer */
-    uint8_t     bIsTransferDone;      /*!< tansfer done?                         \hideinitializer */
+    volatile uint8_t bIsTransferDone; /*!< tansfer done?                         \hideinitializer */
     uint32_t    data_len;             /*!< length of data to be transferred      \hideinitializer */
     uint32_t    xfer_len;             /*!< length of transferred data            \hideinitializer */
     uint8_t     bIsoNewSched;         /*!< New schedule isochronous transfer     \hideinitializer */


### PR DESCRIPTION
This is the fix for https://github.com/XboxDev/nxdk/issues/624

The problem occurs in the following code, which waits on a change in `utr->bIsTransferDone` by the IRQ handler:

https://github.com/XboxDev/libusbohci/blob/b9f167224ea092241ef6ec4d06cea819dfdda0a5/src_core/usb_core.c#L321-L331

Because `utr->bIsTransferDone` is not marked volatile, the compiler can assume that its value never changes after the first comparison as it is not modified in the loop. Interestingly, this only caused defective code to be emitted if `get_ticks` got inlined.