### PR TITLE
OHCI: Put ohci in reset state on shutdown

### DIFF
--- a/src_core/ohci.c
+++ b/src_core/ohci.c
@@ -259,6 +259,8 @@ static void ohci_shutdown(void)
 #ifndef OHCI_PER_PORT_POWER
     _ohci->HcRhStatus = USBH_HcRhStatus_LPS_Msk;
 #endif
+    uint32_t HcControl = _ohci->HcControl;
+    _ohci->HcControl = HcControl & USBH_HcControl_CBSR_Msk;
 }
 
 


### PR DESCRIPTION
When launching an XDK title from an nxdk based application, the controller input would not always come up if you have setup USB.

It turns out XDK expects OHCI to be in USB reset state, instead we were putting it into suspend state.

This fix simply puts ohci in this state on shutdown.

Although this could be considered xbox specific, there is no issues with doing this on shutdown with typical applications and it is probably more common.